### PR TITLE
Update production URL for GitHub Pages

### DIFF
--- a/docs/manifest.xml
+++ b/docs/manifest.xml
@@ -6,8 +6,8 @@
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Jaxs Ai"/>
   <Description DefaultValue="A template to get started."/>
-  <IconUrl DefaultValue="https://localhost:3000/assets/icon-32.png"/>
-  <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-64.png"/>
+  <IconUrl DefaultValue="https://neverneverbabe.github.io/exceljax/assets/icon-32.png"/>
+  <HighResolutionIconUrl DefaultValue="https://neverneverbabe.github.io/exceljax/assets/icon-64.png"/>
   <SupportUrl DefaultValue="https://www.contoso.com/help"/>
   <AppDomains>
     <AppDomain>https://www.contoso.com</AppDomain>
@@ -16,7 +16,7 @@
     <Host Name="Workbook"/>
   </Hosts>
   <DefaultSettings>
-    <SourceLocation DefaultValue="https://localhost:3000/taskpane.html"/>
+    <SourceLocation DefaultValue="https://neverneverbabe.github.io/exceljax/taskpane.html"/>
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -62,14 +62,14 @@
     </Hosts>
     <Resources>
       <bt:Images>
-        <bt:Image id="Icon.16x16" DefaultValue="https://localhost:3000/assets/icon-16.png"/>
-        <bt:Image id="Icon.32x32" DefaultValue="https://localhost:3000/assets/icon-32.png"/>
-        <bt:Image id="Icon.80x80" DefaultValue="https://localhost:3000/assets/icon-80.png"/>
+        <bt:Image id="Icon.16x16" DefaultValue="https://neverneverbabe.github.io/exceljax/assets/icon-16.png"/>
+        <bt:Image id="Icon.32x32" DefaultValue="https://neverneverbabe.github.io/exceljax/assets/icon-32.png"/>
+        <bt:Image id="Icon.80x80" DefaultValue="https://neverneverbabe.github.io/exceljax/assets/icon-80.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
-        <bt:Url id="Commands.Url" DefaultValue="https://localhost:3000/commands.html"/>
-        <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3000/taskpane.html"/>
+        <bt:Url id="Commands.Url" DefaultValue="https://neverneverbabe.github.io/exceljax/commands.html"/>
+        <bt:Url id="Taskpane.Url" DefaultValue="https://neverneverbabe.github.io/exceljax/taskpane.html"/>
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with your sample add-in!"/>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const urlDev = "https://localhost:3000/";
-const urlProd = "https://www.contoso.com/"; // CHANGE THIS TO YOUR PRODUCTION DEPLOYMENT LOCATION
+const urlProd = "https://neverneverbabe.github.io/exceljax/"; // Updated for GitHub Pages
 
 async function getHttpsOptions() {
   const httpsOptions = await devCerts.getHttpsServerOptions();


### PR DESCRIPTION
## Summary
- update production deployment URL in webpack config
- rebuild docs manifest so it uses the GitHub Pages address

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684286bba90083239030cdbe963c1305