### PR TITLE
Add simple task runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ npx http-server docs -S   # serve the built files from the docs folder
 ```
 
 Office requires add-ins to run from HTTPS, so make sure the local server uses HTTPS certificates.
+
+## Task script
+
+Use `scripts/tasks.js` to run common project tasks from the command line:
+
+```bash
+node scripts/tasks.js install       # run npm install
+node scripts/tasks.js build         # build for production
+node scripts/tasks.js buildGhPages  # build for GitHub Pages
+node scripts/tasks.js proxy         # start the local LLM proxy
+node scripts/tasks.js start         # launch the add-in locally
+```
+

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "start": "office-addin-debugging start manifest.xml",
     "stop": "office-addin-debugging stop manifest.xml",
     "validate": "office-addin-manifest validate manifest.xml",
-    "watch": "webpack --mode development --watch"
+    "watch": "webpack --mode development --watch",
+    "tasks": "node scripts/tasks.js"
   },
   "dependencies": {
     "core-js": "^3.36.0",

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -1,0 +1,32 @@
+const { execSync } = require('child_process');
+
+function run(command) {
+  execSync(command, { stdio: 'inherit' });
+}
+
+const tasks = {
+  install() {
+    run('npm install');
+  },
+  build() {
+    run('npm run build');
+  },
+  buildGhPages() {
+    run('npm run build:ghpages');
+  },
+  proxy() {
+    run('node proxy-server.js');
+  },
+  start() {
+    run('npm start');
+  },
+};
+
+const task = process.argv[2];
+if (!task || !tasks[task]) {
+  console.log('Usage: node scripts/tasks.js <task>');
+  console.log('Available tasks: ' + Object.keys(tasks).join(', '));
+  process.exit(1);
+}
+
+tasks[task]();


### PR DESCRIPTION
## Summary
- add a `scripts/tasks.js` helper that wraps common project commands
- document how to use the task script in README
- expose `npm run tasks` for convenience

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684288c59bbc83238785891f823b2088