### PR TITLE
Add configurable AI settings and chat history

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -92,6 +92,17 @@ textarea#promptInput {
     overflow-y: auto;
 }
 
+#status {
+    margin-top: 6px;
+    color: red;
+    width: 100%;
+}
+
+.settings-input {
+    width: 100%;
+    margin-top: 6px;
+}
+
 .action-btn {
     margin-top: 10px;
     width: 100%;

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -51,6 +51,13 @@
       <textarea id="promptInput" rows="3" placeholder="Ask a question..." class="ms-TextField"></textarea>
       <button id="chatBtn" class="ms-Button ms-Button--primary action-btn">🔍 Chat with AI</button>
       <div id="chatOutput" class="output"></div>
+      <div id="status" class="status"></div>
+    </div>
+
+    <div id="settings-section" style="width: 100%; margin-top: 10px;">
+      <input id="endpointInput" class="ms-TextField settings-input" placeholder="LLM endpoint" />
+      <input id="modelInput" class="ms-TextField settings-input" placeholder="Model ID" />
+      <button id="saveSettingsBtn" class="ms-Button ms-Button--primary action-btn">Save Settings</button>
     </div>
 
     <button id="analyzeSelectionBtn" class="ms-Button ms-Button--primary action-btn">📊 Analyze Selected Cells</button>


### PR DESCRIPTION
## Summary
- allow configuring the LLM endpoint and model
- persist these settings in localStorage
- maintain conversation history in chat
- show status/errors in taskpane

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684291fe29b88323ad504680e3cafbbc