### PR TITLE
Add tutorial features

### DIFF
--- a/src/dialogs/popup.html
+++ b/src/dialogs/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head lang="en">
+        <title>Dialog for My Office Add-in</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>
+        <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+        <script type="text/javascript" src="popup.js"></script>
+    </head>
+    <body style="display:flex;flex-direction:column;align-items:center;justify-content:center">
+        <p class="ms-font-xl">ENTER YOUR NAME</p>
+        <input id="name-box" type="text"/><br/><br/>
+        <button id="ok-button" class="ms-Button">OK</button>
+    </body>
+</html>

--- a/src/dialogs/popup.js
+++ b/src/dialogs/popup.js
@@ -1,0 +1,18 @@
+/* global Office, document, console */
+
+Office.onReady(() => {
+  document.getElementById("ok-button").onclick = () => tryCatch(sendStringToParentPage);
+});
+
+function sendStringToParentPage() {
+  const userName = document.getElementById("name-box").value;
+  Office.context.ui.messageParent(userName);
+}
+
+async function tryCatch(callback) {
+  try {
+    await callback();
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -65,6 +65,13 @@
     <button id="suggestFormulaBtn" class="ms-Button ms-Button--primary action-btn">🧠 Suggest Formula for Selected Cells</button>
     <button id="improveFormulaBtn" class="ms-Button ms-Button--primary action-btn">✍️ Improve Existing Formula</button>
     <button id="createVisualsBtn" class="ms-Button ms-Button--primary action-btn">📈 Create Visuals Based on Data</button>
+    <button class="ms-Button" id="create-table">Create Table</button><br/><br/>
+    <button class="ms-Button" id="filter-table">Filter Table</button><br/><br/>
+    <button class="ms-Button" id="sort-table">Sort Table</button><br/><br/>
+    <button class="ms-Button" id="create-chart">Create Chart</button><br/><br/>
+    <button class="ms-Button" id="freeze-header">Freeze Header</button><br/><br/>
+    <button class="ms-Button" id="open-dialog">Open Dialog</button><br/><br/>
+    <label id="user-name"></label><br/><br/>
   </main>
 </body>
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -8,6 +8,7 @@ const defaultConfig = {
 let config = { ...defaultConfig, ...JSON.parse(localStorage.getItem("llmConfig") || "{}") };
 const conversationHistory = [];
 let statusElem;
+let dialog = null;
 
 function saveConfig() {
   localStorage.setItem("llmConfig", JSON.stringify(config));
@@ -29,6 +30,12 @@ Office.onReady((info) => {
     document.getElementById("suggestFormulaBtn").onclick = suggestFormulaForSelectedCells;
     document.getElementById("improveFormulaBtn").onclick = improveExistingFormula;
     document.getElementById("createVisualsBtn").onclick = createVisualsBasedOnData;
+    document.getElementById("create-table").onclick = createTable;
+    document.getElementById("filter-table").onclick = filterTable;
+    document.getElementById("sort-table").onclick = sortTable;
+    document.getElementById("create-chart").onclick = createChart;
+    document.getElementById("freeze-header").onclick = freezeHeader;
+    document.getElementById("open-dialog").onclick = openDialog;
     document.getElementById("saveSettingsBtn").onclick = () => {
       config.endpoint =
         document.getElementById("endpointInput").value.trim() || defaultConfig.endpoint;
@@ -237,4 +244,119 @@ async function createVisualsBasedOnData() {
       statusElem.textContent = "Error communicating with LLM";
     }
   }
+}
+
+async function createTable() {
+  try {
+    await Excel.run(async (context) => {
+      const currentWorksheet = context.workbook.worksheets.getActiveWorksheet();
+      const expensesTable = currentWorksheet.tables.add("A1:D1", true);
+      expensesTable.name = "ExpensesTable";
+
+      expensesTable.getHeaderRowRange().values = [["Date", "Merchant", "Category", "Amount"]];
+
+      expensesTable.rows.add(null, [
+        ["1/1/2017", "The Phone Company", "Communications", "120"],
+        ["1/2/2017", "Northwind Electric Cars", "Transportation", "142.33"],
+        ["1/5/2017", "Best For You Organics Company", "Groceries", "27.9"],
+        ["1/10/2017", "Coho Vineyard", "Restaurant", "33"],
+        ["1/11/2017", "Bellows College", "Education", "350.1"],
+        ["1/15/2017", "Trey Research", "Other", "135"],
+        ["1/15/2017", "Best For You Organics Company", "Groceries", "97.88"],
+      ]);
+
+      expensesTable.columns.getItemAt(3).getRange().numberFormat = [["\u20AC#,##0.00"]];
+      expensesTable.getRange().format.autofitColumns();
+      expensesTable.getRange().format.autofitRows();
+
+      await context.sync();
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function filterTable() {
+  try {
+    await Excel.run(async (context) => {
+      const currentWorksheet = context.workbook.worksheets.getActiveWorksheet();
+      const expensesTable = currentWorksheet.tables.getItem("ExpensesTable");
+      const categoryColumn = expensesTable.columns.getItem("Category");
+      categoryColumn.load("filter");
+      await context.sync();
+      categoryColumn.filter.applyValuesFilter(["Education", "Groceries"]);
+      await context.sync();
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function sortTable() {
+  try {
+    await Excel.run(async (context) => {
+      const currentWorksheet = context.workbook.worksheets.getActiveWorksheet();
+      const expensesTable = currentWorksheet.tables.getItem("ExpensesTable");
+      const sortFields = [
+        {
+          key: 1,
+          ascending: false,
+        },
+      ];
+
+      expensesTable.sort.apply(sortFields);
+      await context.sync();
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function createChart() {
+  try {
+    await Excel.run(async (context) => {
+      const currentWorksheet = context.workbook.worksheets.getActiveWorksheet();
+      const expensesTable = currentWorksheet.tables.getItem("ExpensesTable");
+      const dataRange = expensesTable.getDataBodyRange();
+      const chart = currentWorksheet.charts.add("ColumnClustered", dataRange, "Auto");
+      chart.setPosition("A15", "F30");
+      chart.title.text = "Expenses";
+      chart.legend.position = "Right";
+      chart.legend.format.fill.setSolidColor("white");
+      chart.dataLabels.format.font.size = 15;
+      chart.dataLabels.format.font.color = "black";
+      chart.series.getItemAt(0).name = "Value in \u20AC";
+      await context.sync();
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function freezeHeader() {
+  try {
+    await Excel.run(async (context) => {
+      const currentWorksheet = context.workbook.worksheets.getActiveWorksheet();
+      currentWorksheet.freezePanes.freezeRows(1);
+      await context.sync();
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function openDialog() {
+  Office.context.ui.displayDialogAsync(
+    "https://localhost:3000/popup.html",
+    { height: 45, width: 55 },
+    function (result) {
+      dialog = result.value;
+      dialog.addEventHandler(Office.EventType.DialogMessageReceived, processMessage);
+    }
+  );
+}
+
+function processMessage(arg) {
+  document.getElementById("user-name").innerHTML = arg.message;
+  dialog.close();
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = async (env, options) => {
       polyfill: ["core-js/stable", "regenerator-runtime/runtime"],
       taskpane: ["./src/taskpane/taskpane.js", "./src/taskpane/taskpane.html"],
       commands: "./src/commands/commands.js",
+      popup: "./src/dialogs/popup.js",
     },
     output: {
       clean: true,
@@ -89,6 +90,11 @@ module.exports = async (env, options) => {
         filename: "commands.html",
         template: "./src/commands/commands.html",
         chunks: ["polyfill", "commands"],
+      }),
+      new HtmlWebpackPlugin({
+        filename: "popup.html",
+        template: "./src/dialogs/popup.html",
+        chunks: ["polyfill", "popup"],
       }),
     ],
     devServer: {


### PR DESCRIPTION
## Summary
- support popup dialog and add Excel sample features
- wire up table creation, filtering, sorting, and charting
- enable header freezing and dialog display
- update build config for dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842a48c086c8323950f05ede960c6fb