### PR TITLE
Fix default endpoint and payload for LM Studio

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1,7 +1,7 @@
 /* global console, document, Excel, Office, fetch, localStorage */
 
 const defaultConfig = {
-  endpoint: "http://localhost:4321/v1/completions",
+  endpoint: "http://localhost:1234/v1/chat/completions",
   model: "meta-llama-3.1-8b-instruct",
 };
 
@@ -55,9 +55,9 @@ async function sendToLLM(prompt) {
     },
     body: JSON.stringify({
       model: config.model,
-      prompt: prompt,
-      max_tokens: 200,
+      messages: [{ role: "user", content: prompt }],
       temperature: 0.7,
+      stream: false,
     }),
   }).catch((err) => {
     console.error("❌ Fetch error:", err);


### PR DESCRIPTION
## Summary
- update default LLM endpoint for LM Studio
- send chat-style payload with `messages`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b09085348323b850f4e720edf603