### PR TITLE
Rename gitignore and ignore build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+dist-ghpages/
+docs/
 .env
 .DS_Store
 npm-debug.log*


### PR DESCRIPTION
## Summary
- rename `gitignore.txt` to `.gitignore`
- add `dist-ghpages/` and `docs/` to ignore list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684377242e508323a8b99d43e307dbf9