### PR TITLE
Enable office debugging scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/taskpane.js",
   "scripts": {
     "test": "echo \"No tests defined\" && exit 0",
-    "build": "webpack && cp manifest.xml dist/ && cp manifest.xml docs/ && cp manifest.xml dist-ghpages/"
+    "build": "webpack && cp manifest.xml dist/ && cp manifest.xml docs/ && cp manifest.xml dist-ghpages/",
+    "start": "office-addin-debugging start manifest.xml",
+    "stop": "office-addin-debugging stop manifest.xml"
   },
   "author": "Your Name",
   "license": "MIT",
@@ -13,6 +15,7 @@
     "copy-webpack-plugin": "^13.0.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.6.3",
+    "office-addin-debugging": "^6.0.3",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0"
   }


### PR DESCRIPTION
## Summary
- add `start` and `stop` scripts to sideload the add‑in in Excel
- include `office-addin-debugging` as a development dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438db295c08323a98cc3d5f6c18b34