### PR TITLE
Add npm task aliases and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It allows you to use local LLMs running in LM Studio for data analysis, formula 
 1. **Install dependencies:**  
    `npm ci`
 
-2. **Development build:**  
-   `npm run build`
+2. **Development build:**
+   `npm run build:dev`
 
 3. **Deploy:**  
    Just push to `main` — GitHub Actions builds and publishes automatically!
@@ -25,6 +25,19 @@ It allows you to use local LLMs running in LM Studio for data analysis, formula 
 
 5. **Start LM Studio:**  
    Make sure LM Studio is running and listening on `http://localhost:1234`.
+
+## Available Scripts
+
+- `npm run build` – Production build with Webpack.
+- `npm run build:dev` – Development build.
+- `npm run build:ghpages` – Build using the GitHub Pages configuration.
+- `npm run dev-server` – Run a development server with live reload.
+- `npm run watch` – Watch source files and rebuild on changes.
+- `npm run start` – Launch the add-in for debugging.
+- `npm run stop` – Stop the debugging session.
+- `npm run lint` – Check code style with ESLint.
+- `npm run lint:fix` – Fix fixable linting issues.
+- `npm run proxy` – Start the LM Studio proxy server.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "main": "dist/taskpane.js",
   "scripts": {
     "test": "echo \"No tests defined\" && exit 0",
-    "build": "webpack && cp manifest.xml dist/ && cp manifest.xml docs/ && cp manifest.xml dist-ghpages/",
+    "build": "webpack --mode production && cp manifest.xml dist/ && cp manifest.xml docs/ && cp manifest.xml dist-ghpages/",
+    "build:dev": "webpack --mode development",
+    "build:ghpages": "webpack --config webpack.ghpages.config.js",
+    "dev-server": "webpack serve --mode development",
+    "lint": "office-addin-lint check",
+    "lint:fix": "office-addin-lint fix",
+    "watch": "webpack --watch --mode development",
     "start": "office-addin-debugging start manifest.xml",
     "stop": "office-addin-debugging stop manifest.xml",
     "proxy": "node proxy-server.js"
@@ -14,11 +20,15 @@
   "license": "MIT",
   "devDependencies": {
     "copy-webpack-plugin": "^13.0.0",
+    "eslint": "^9.28.0",
+    "eslint-plugin-office-addins": "^4.0.3",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.6.3",
     "office-addin-debugging": "^6.0.3",
+    "office-addin-lint": "^3.0.3",
     "webpack": "^5.0.0",
-    "webpack-cli": "^4.0.0"
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- wire up npm scripts used by VS Code tasks
- document available npm scripts
- include lint and dev server dependencies

## Testing
- `npm test`
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68438fbdef5483238b907647e5b42ae3