### PR TITLE
Document proxy server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ It allows you to use local LLMs running in LM Studio for data analysis, formula 
 - `/dist` — built output, deployed to GitHub Pages (`main` branch → `gh-pages` branch)
 - `.github/workflows/deploy.yml` — CI/CD for automatic deployment
 
+## Proxy Server
+
+`proxy-server.js` forwards requests from `http://localhost:4321/v1` to the LM Studio API at `http://127.0.0.1:1234/v1`. This helps avoid CORS issues when the add-in accesses local models.
+
+Start the proxy with:
+
+```bash
+npm run proxy
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- document the purpose of `proxy-server.js`
- show how to start the proxy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684397f9f67c83239d10f564ad57d2e8