### PR TITLE
Add configurable LM API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It allows you to use local LLMs running in LM Studio for data analysis, formula 
 
 ## Features
 
-- Dynamically loads available models from LM Studio (`http://localhost:1234/v1/models`)
+- Dynamically loads available models from LM Studio (endpoint set via `LM_API_URL`)
 - AI chat, formula help, insights, and data cleanup tools in the Excel Task Pane
 - Deployed and updated automatically via GitHub Actions to GitHub Pages
 
@@ -23,8 +23,13 @@ It allows you to use local LLMs running in LM Studio for data analysis, formula 
 4. **Update manifest:**  
    Download `manifest.xml` from your repo and [sideload it in Excel](https://learn.microsoft.com/office/dev/add-ins/testing/sideload-office-add-ins-for-testing).
 
-5. **Start LM Studio:**  
+5. **Start LM Studio:**
    Make sure LM Studio is running and listening on `http://localhost:1234`.
+
+## Environment Variables
+
+Set `LM_API_URL` to change the endpoint used to fetch model metadata.
+If not specified, it defaults to `http://localhost:1234/v1/models`.
 
 ## Available Scripts
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1,3 +1,9 @@
+/* global document, fetch, console, LM_API_URL */
+const DEFAULT_LM_API_URL = "http://localhost:1234/v1/models";
+// LM_API_URL is replaced at build time via Webpack's DefinePlugin.
+const MODELS_URL =
+  typeof LM_API_URL !== "undefined" ? LM_API_URL : DEFAULT_LM_API_URL;
+
 document.addEventListener("DOMContentLoaded", () => {
   const modelDropdown = document.getElementById("modelDropdown");
   const modelError = document.getElementById("modelError");
@@ -8,7 +14,7 @@ document.addEventListener("DOMContentLoaded", () => {
     modelError.textContent = "";
     modelDropdown.disabled = true;
     try {
-      const res = await fetch("http://localhost:1234/v1/models");
+      const res = await fetch(MODELS_URL);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (!Array.isArray(data.models))
@@ -22,6 +28,7 @@ document.addEventListener("DOMContentLoaded", () => {
       });
       modelDropdown.disabled = false;
     } catch (err) {
+      console.error(err);
       modelDropdown.innerHTML = `<option disabled>Error loading models</option>`;
       modelError.textContent =
         "LM Studio is not running. Features requiring LLMs are disabled.";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
   entry: {
@@ -14,6 +15,9 @@ module.exports = {
       filename: 'taskpane.html',
       template: './src/taskpane/taskpane.html',
       chunks: ['taskpane'],
+    }),
+    new webpack.DefinePlugin({
+      LM_API_URL: JSON.stringify(process.env.LM_API_URL || 'http://localhost:1234/v1/models'),
     }),
   ],
   module: {


### PR DESCRIPTION
## Summary
- inject `LM_API_URL` via Webpack DefinePlugin
- use the new variable in `taskpane.js`
- document the configuration option

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843b37a5dd083238bff7cee16e6fd35