### PR TITLE
Add reconnection logic for model loading

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -9,16 +9,27 @@ document.addEventListener("DOMContentLoaded", () => {
   const modelError = document.getElementById("modelError");
   const modelSpinner = document.getElementById("spinner");
 
+  const RETRY_DELAY_MS = 5000;
+  let retryTimeout = null;
+
   async function loadModels() {
+    // clear any pending retry since we're attempting a fetch now
+    if (retryTimeout) {
+      clearTimeout(retryTimeout);
+      retryTimeout = null;
+    }
+
     modelSpinner.style.display = "inline-block";
     modelError.textContent = "";
     modelDropdown.disabled = true;
+
     try {
       const res = await fetch(MODELS_URL);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (!Array.isArray(data.models))
         throw new Error("Unexpected model response");
+
       modelDropdown.innerHTML = "";
       data.models.forEach((model) => {
         const opt = document.createElement("option");
@@ -26,15 +37,18 @@ document.addEventListener("DOMContentLoaded", () => {
         opt.textContent = model.id;
         modelDropdown.appendChild(opt);
       });
+
       modelDropdown.disabled = false;
+      modelSpinner.style.display = "none";
     } catch (err) {
       console.error(err);
       modelDropdown.innerHTML = `<option disabled>Error loading models</option>`;
       modelError.textContent =
-        "LM Studio is not running. Features requiring LLMs are disabled.";
+        "LM Studio is not running. Retrying connection...";
       modelDropdown.disabled = true;
-    } finally {
-      modelSpinner.style.display = "none";
+
+      // schedule another attempt to fetch models
+      retryTimeout = setTimeout(loadModels, RETRY_DELAY_MS);
     }
   }
 


### PR DESCRIPTION
## Summary
- retry fetching models every 5s when the request fails
- keep spinner visible and inform user that reconnection is in progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843b5edc8608323b514cb1d3ef31302