### PR TITLE
Add model selection elements in taskpane

### DIFF
--- a/dist/taskpane.html
+++ b/dist/taskpane.html
@@ -11,7 +11,7 @@
       padding: 10px 20px;
       font-size: 14px;
       margin-top: 15px;
-    }</style><script defer="defer" src="taskpane.js"></script></head><body><h1>LIVE VERSION — GitHub Pages</h1><p>This taskpane is being loaded from GitHub Pages and works in Excel Web and Desktop.</p><button onclick="writeToExcel()">Write to Excel</button> <select id="modelDropdown"></select> <span id="modelError"></span> <span id="spinner" style="display:none">Loading...</span><script>Office.onReady(info => {
+    }</style><script defer="defer" src="taskpane.js"></script></head><body><h1>LIVE VERSION — GitHub Pages</h1><p>This taskpane is being loaded from GitHub Pages and works in Excel Web and Desktop.</p><button onclick="writeToExcel()">Write to Excel</button><div id="modelSection"><select id="modelDropdown"></select> <span id="modelError"></span> <span id="spinner" style="display:none">Loading...</span></div><script>Office.onReady(info => {
       if (info.host === Office.HostType.Excel) {
         console.log("Excel is ready.");
       }

--- a/docs/taskpane.html
+++ b/docs/taskpane.html
@@ -11,7 +11,7 @@
       padding: 10px 20px;
       font-size: 14px;
       margin-top: 15px;
-    }</style><script defer="defer" src="taskpane.js"></script></head><body><h1>LIVE VERSION — GitHub Pages</h1><p>This taskpane is being loaded from GitHub Pages and works in Excel Web and Desktop.</p><button onclick="writeToExcel()">Write to Excel</button> <select id="modelDropdown"></select> <span id="modelError"></span> <span id="spinner" style="display:none">Loading...</span><script>Office.onReady(info => {
+    }</style><script defer="defer" src="taskpane.js"></script></head><body><h1>LIVE VERSION — GitHub Pages</h1><p>This taskpane is being loaded from GitHub Pages and works in Excel Web and Desktop.</p><button onclick="writeToExcel()">Write to Excel</button><div id="modelSection"><select id="modelDropdown"></select> <span id="modelError"></span> <span id="spinner" style="display:none">Loading...</span></div><script>Office.onReady(info => {
       if (info.host === Office.HostType.Excel) {
         console.log("Excel is ready.");
       }

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -28,9 +28,12 @@
 
   <button onclick="writeToExcel()">Write to Excel</button>
 
-  <select id="modelDropdown"></select>
-  <span id="modelError"></span>
-  <span id="spinner" style="display:none">Loading...</span>
+  <!-- Language model selection -->
+  <div id="modelSection">
+    <select id="modelDropdown"></select>
+    <span id="modelError"></span>
+    <span id="spinner" style="display:none">Loading...</span>
+  </div>
 
   <script>
     Office.onReady(info => {


### PR DESCRIPTION
## Summary
- extend taskpane UI with a section for model selection
- rebuild HTML in dist/ and docs/

## Testing
- `npm run build`
- `npm run build:ghpages`
- `npm test`
- `node - <<'NODE'
const fs = require('fs');
const { JSDOM } = require('jsdom');
const html = fs.readFileSync('src/taskpane/taskpane.html', 'utf8');
const dom = new JSDOM(html, { runScripts: 'outside-only' });
const window = dom.window;
window.Office = {HostType:{Excel:'Excel'}, onReady:(cb)=>cb({host:'Excel'})};
window.fetch = (...args)=>Promise.resolve({ok:true,json:()=>Promise.resolve({models:[{id:'test'}]})});
window.console = console;
const script = fs.readFileSync('src/taskpane/taskpane.js','utf8');
window.eval(script);
window.document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
setTimeout(()=>{ console.log('modelDropdown value:', window.document.getElementById('modelDropdown').value); },500);
NODE

------
https://chatgpt.com/codex/tasks/task_e_6843dca3dab88323a3c5fdd82ebbe87a